### PR TITLE
incremental scan: build delete index. only load from main & original; incremental indexing;

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -336,8 +336,7 @@ int index_args_validate(index_args_t *args, int argc, const char **argv) {
     if (index_path == NULL) {
         LOG_FATALF("cli.c", "Invalid PATH argument. File not found: %s", argv[1])
     } else {
-        args->index_path = argv[1];
-        free(index_path);
+        args->index_path = index_path;
     }
 
     if (args->es_url == NULL) {
@@ -522,8 +521,7 @@ int exec_args_validate(exec_args_t *args, int argc, const char **argv) {
     if (index_path == NULL) {
         LOG_FATALF("cli.c", "Invalid index PATH argument. File not found: %s", argv[1])
     } else {
-        args->index_path = argv[1];
-        free(index_path);
+        args->index_path = index_path;
     }
 
     if (args->es_url == NULL) {

--- a/src/cli.h
+++ b/src/cli.h
@@ -56,6 +56,7 @@ typedef struct index_args {
     int async_script;
     int force_reset;
     int threads;
+    int incremental;
 } index_args_t;
 
 typedef struct web_args {

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -41,6 +41,7 @@ typedef struct {
 
     GHashTable *original_table;
     GHashTable *copy_table;
+    GHashTable *new_table;
     pthread_mutex_t copy_table_mu;
 
     pcre *exclude;

--- a/src/index/elastic.c
+++ b/src/index/elastic.c
@@ -52,11 +52,22 @@ void index_json_func(void *arg) {
     elastic_index_line(line);
 }
 
+void delete_document(const char* document_id_str, void* UNUSED(_data)) {
+    size_t id_len = strlen(document_id_str);
+    es_bulk_line_t *bulk_line = malloc(sizeof(es_bulk_line_t));
+    bulk_line->type = ES_BULK_LINE_DELETE;
+    bulk_line->next = NULL;
+    memcpy(bulk_line->path_md5_str, document_id_str, MD5_STR_LENGTH);
+    tpool_add_work(IndexCtx.pool, index_json_func, bulk_line);
+}
+
+
 void index_json(cJSON *document, const char index_id_str[MD5_STR_LENGTH]) {
     char *json = cJSON_PrintUnformatted(document);
 
     size_t json_len = strlen(json);
     es_bulk_line_t *bulk_line = malloc(sizeof(es_bulk_line_t) + json_len + 2);
+    bulk_line->type = ES_BULK_LINE_INDEX;
     memcpy(bulk_line->line, json, json_len);
     memcpy(bulk_line->path_md5_str, index_id_str, MD5_STR_LENGTH);
     *(bulk_line->line + json_len) = '\n';
@@ -65,11 +76,6 @@ void index_json(cJSON *document, const char index_id_str[MD5_STR_LENGTH]) {
 
     cJSON_free(json);
     tpool_add_work(IndexCtx.pool, index_json_func, bulk_line);
-}
-
-void delete_document(const char* document_id_str, void* data) {
-    const char* index_id_str = data;
-    // TODO bulk delete
 }
 
 void execute_update_script(const char *script, int async, const char index_id[MD5_STR_LENGTH]) {
@@ -130,30 +136,47 @@ void *create_bulk_buffer(int max, int *count, size_t *buf_len) {
     size_t buf_cur = 0;
     char *buf = malloc(8192);
     size_t buf_capacity = 8192;
+#define GROW_BUF(delta)                       \
+    while (buf_size + (delta) > buf_capacity) { \
+      buf_capacity *= 2;                        \
+      buf = realloc(buf, buf_capacity);         \
+    }                                           \
+    buf_size += (delta);                        \
 
+    // see: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
+    // ES_BULK_LINE_INDEX: two lines, 1st action, 2nd content
+    // ES_BULK_LINE_DELETE: one line
     while (line != NULL && *count < max) {
         char action_str[256];
-        snprintf(
-                action_str, sizeof(action_str),
-                "{\"index\":{\"_id\":\"%s\",\"_type\":\"_doc\",\"_index\":\"%s\"}}\n",
-                line->path_md5_str, Indexer->es_index
-        );
+        if (line->type == ES_BULK_LINE_INDEX) {
+            snprintf(
+                    action_str, sizeof(action_str),
+                    "{\"index\":{\"_id\":\"%s\",\"_type\":\"_doc\",\"_index\":\"%s\"}}\n",
+                    line->path_md5_str, Indexer->es_index
+            );
 
-        size_t action_str_len = strlen(action_str);
-        size_t line_len = strlen(line->line);
+            size_t action_str_len = strlen(action_str);
+            size_t line_len = strlen(line->line);
 
-        while (buf_size + line_len + action_str_len > buf_capacity) {
-            buf_capacity *= 2;
-            buf = realloc(buf, buf_capacity);
+            GROW_BUF(action_str_len + line_len);
+
+            memcpy(buf + buf_cur, action_str, action_str_len);
+            buf_cur += action_str_len;
+            memcpy(buf + buf_cur, line->line, line_len);
+            buf_cur += line_len;
+
+        } else if (line->type == ES_BULK_LINE_DELETE) {
+            snprintf(
+                    action_str, sizeof(action_str),
+                    "{\"delete\":{\"_id\":\"%s\",\"_index\":\"%s\"}}\n",
+                    line->path_md5_str, Indexer->es_index
+            );
+
+            size_t action_str_len = strlen(action_str);
+            GROW_BUF(action_str_len);
+            memcpy(buf + buf_cur, action_str, action_str_len);
+            buf_cur += action_str_len;
         }
-
-        buf_size += line_len + action_str_len;
-
-        memcpy(buf + buf_cur, action_str, action_str_len);
-        buf_cur += action_str_len;
-        memcpy(buf + buf_cur, line->line, line_len);
-        buf_cur += line_len;
-
         line = line->next;
         (*count)++;
     }

--- a/src/index/elastic.h
+++ b/src/index/elastic.h
@@ -40,6 +40,8 @@ void print_json(cJSON *document, const char index_id_str[MD5_STR_LENGTH]);
 
 void index_json(cJSON *document, const char index_id_str[MD5_STR_LENGTH]);
 
+void delete_document(const char *document_id_str, void* data);
+
 es_indexer_t *create_indexer(const char *url, const char *index);
 
 void elastic_cleanup();

--- a/src/index/elastic.h
+++ b/src/index/elastic.h
@@ -3,9 +3,13 @@
 
 #include "src/sist.h"
 
+#define ES_BULK_LINE_INDEX 0
+#define ES_BULK_LINE_DELETE 1
+
 typedef struct es_bulk_line {
     struct es_bulk_line *next;
     char path_md5_str[MD5_STR_LENGTH];
+    int type;
     char line[0];
 } es_bulk_line_t;
 

--- a/src/io/serialize.c
+++ b/src/io/serialize.c
@@ -486,6 +486,7 @@ void incremental_read(GHashTable *table, const char *filepath, index_descriptor_
 }
 
 static __thread GHashTable *IncrementalCopyTable = NULL;
+static __thread GHashTable *IncrementalNewTable = NULL;
 static __thread store_t *IncrementalCopySourceStore = NULL;
 static __thread store_t *IncrementalCopyDestinationStore = NULL;
 
@@ -535,20 +536,32 @@ void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
     read_index(filepath, "", INDEX_TYPE_NDJSON, incremental_copy_handle_doc);
 }
 
-void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *copy_table, GHashTable *new_table) {
-    GHashTableIter iter;
-    gpointer key, UNUSED(value);
-    char path_md5[MD5_STR_LENGTH + 1];
-    path_md5[MD5_STR_LENGTH] = '\0';
-    path_md5[MD5_STR_LENGTH - 1] = '\n';
-    initialize_writer_ctx(del_filepath);
-    g_hash_table_iter_init(&iter, orig_table);
-    while(g_hash_table_iter_next(&iter, &key, &value)) {
-        if (NULL == g_hash_table_lookup(new_table, key) && 
-            NULL == g_hash_table_lookup(copy_table, key)) {
-            memcpy(path_md5, key, MD5_STR_LENGTH - 1);
-            zstd_write_string(path_md5, MD5_STR_LENGTH);
-        }
+void incremental_delete_handle_doc(cJSON *document, UNUSED(const char id_str[MD5_STR_LENGTH])) {
+
+    char path_md5_n[MD5_STR_LENGTH + 1];
+    path_md5_n[MD5_STR_LENGTH] = '\0';
+    path_md5_n[MD5_STR_LENGTH - 1] = '\n';
+    const char *path_md5_str = cJSON_GetObjectItem(document, "_id")->valuestring;
+
+    // do not delete archive virtual entries
+    if (cJSON_GetObjectItem(document, "parent") == NULL 
+        && !incremental_get_str(IncrementalCopyTable, path_md5_str)
+        && !incremental_get_str(IncrementalNewTable, path_md5_str)
+        ) {
+        memcpy(path_md5_n, path_md5_str, MD5_STR_LENGTH - 1);
+        zstd_write_string(path_md5_n, MD5_STR_LENGTH);
     }
-    writer_cleanup();
+}
+
+void incremental_delete(const char *del_filepath, const char* index_filepath, 
+                        GHashTable *copy_table, GHashTable *new_table) {
+
+    if (WriterCtx.out_file == NULL) {
+        initialize_writer_ctx(del_filepath);
+    }
+
+    IncrementalCopyTable = copy_table;
+    IncrementalNewTable = new_table;
+
+    read_index(index_filepath, "", INDEX_TYPE_NDJSON, incremental_delete_handle_doc);
 }

--- a/src/io/serialize.c
+++ b/src/io/serialize.c
@@ -535,7 +535,7 @@ void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
     read_index(filepath, "", INDEX_TYPE_NDJSON, incremental_copy_handle_doc);
 }
 
-void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *new_table) {
+void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *copy_table, GHashTable *new_table) {
     GHashTableIter iter;
     gpointer key, UNUSED(value);
     char path_md5[MD5_STR_LENGTH + 1];
@@ -544,7 +544,8 @@ void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashT
     initialize_writer_ctx(del_filepath);
     g_hash_table_iter_init(&iter, orig_table);
     while(g_hash_table_iter_next(&iter, &key, &value)) {
-        if (NULL == g_hash_table_lookup(new_table, key)) {
+        if (NULL == g_hash_table_lookup(new_table, key) && 
+            NULL == g_hash_table_lookup(copy_table, key)) {
             memcpy(path_md5, key, MD5_STR_LENGTH - 1);
             zstd_write_string(path_md5, MD5_STR_LENGTH);
         }

--- a/src/io/serialize.c
+++ b/src/io/serialize.c
@@ -524,3 +524,20 @@ void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
 
     read_index(filepath, "", INDEX_TYPE_NDJSON, incremental_copy_handle_doc);
 }
+
+void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *new_table) {
+    GHashTableIter iter;
+    gpointer key, UNUSED(value);
+    char path_md5[MD5_STR_LENGTH + 1];
+    path_md5[MD5_STR_LENGTH] = '\0';
+    path_md5[MD5_STR_LENGTH - 1] = '\n';
+    initialize_writer_ctx(del_filepath);
+    g_hash_table_iter_init(&iter, orig_table);
+    while(g_hash_table_iter_next(&iter, &key, &value)) {
+        if (NULL == g_hash_table_lookup(new_table, key)) {
+            memcpy(path_md5, key, MD5_STR_LENGTH - 1);
+            zstd_write_string(path_md5, MD5_STR_LENGTH);
+        }
+    }
+    writer_cleanup();
+}

--- a/src/io/serialize.h
+++ b/src/io/serialize.h
@@ -12,6 +12,8 @@ typedef void(*index_func)(cJSON *, const char[MD5_STR_LENGTH]);
 void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
                       const char *dst_filepath, GHashTable *copy_table);
 
+void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *new_table);
+
 void write_document(document_t *doc);
 
 void read_index(const char *path, const char[MD5_STR_LENGTH], const char *type, index_func);

--- a/src/io/serialize.h
+++ b/src/io/serialize.h
@@ -17,7 +17,7 @@ typedef void(*index_func)(cJSON *, const char[MD5_STR_LENGTH]);
 void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
                       const char *dst_filepath, GHashTable *copy_table);
 
-void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *new_table);
+void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *copy_table, GHashTable *new_table);
 
 void write_document(document_t *doc);
 

--- a/src/io/serialize.h
+++ b/src/io/serialize.h
@@ -17,7 +17,8 @@ typedef void(*index_func)(cJSON *, const char[MD5_STR_LENGTH]);
 void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
                       const char *dst_filepath, GHashTable *copy_table);
 
-void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *copy_table, GHashTable *new_table);
+void incremental_delete(const char *del_filepath, const char* index_filepath, 
+                        GHashTable *copy_table, GHashTable *new_table);
 
 void write_document(document_t *doc);
 
@@ -47,7 +48,7 @@ index_descriptor_t read_index_descriptor(char *path);
         action_main_fail;                                                               \
     }                                                                                   \
     snprintf(file_path, PATH_MAX, "%s_index_original.ndjson.zst", index_path);          \
-    if ((cond_original) && 0 == access(file_path, R_OK)) {                              \
+    if ((cond_original) && (0 == access(file_path, R_OK))) {                            \
         action_ok;                                                                      \
     }                                                                                   \
 

--- a/src/io/serialize.h
+++ b/src/io/serialize.h
@@ -38,4 +38,18 @@ void write_index_descriptor(char *path, index_descriptor_t *desc);
 
 index_descriptor_t read_index_descriptor(char *path);
 
+// caller ensures char file_path[PATH_MAX]
+#define READ_INDICES(file_path, index_path, action_ok, action_main_fail, cond_original) \
+    snprintf(file_path, PATH_MAX, "%s_index_main.ndjson.zst", index_path);              \
+    if (0 == access(file_path, R_OK)) {                                                 \
+        action_ok;                                                                      \
+    } else {                                                                            \
+        action_main_fail;                                                               \
+    }                                                                                   \
+    snprintf(file_path, PATH_MAX, "%s_index_original.ndjson.zst", index_path);          \
+    if ((cond_original) && 0 == access(file_path, R_OK)) {                              \
+        action_ok;                                                                      \
+    }                                                                                   \
+
+
 #endif

--- a/src/io/serialize.h
+++ b/src/io/serialize.h
@@ -7,6 +7,11 @@
 #include <sys/syscall.h>
 #include <glib.h>
 
+typedef struct line_processor {
+  void* data;
+  void (*func)(const char*, void*);
+} line_processor_t;
+
 typedef void(*index_func)(cJSON *, const char[MD5_STR_LENGTH]);
 
 void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
@@ -15,6 +20,8 @@ void incremental_copy(store_t *store, store_t *dst_store, const char *filepath,
 void incremental_delete(const char *del_filepath, GHashTable *orig_table, GHashTable *new_table);
 
 void write_document(document_t *doc);
+
+void read_lines(const char *path, const line_processor_t processor);
 
 void read_index(const char *path, const char[MD5_STR_LENGTH], const char *type, index_func);
 

--- a/src/main.c
+++ b/src/main.c
@@ -341,7 +341,7 @@ void save_incremental_index(scan_args_t* args) {
     }
 
     snprintf(file_path, PATH_MAX, "%s_index_delete.list.zst", ScanCtx.index.path);
-    incremental_delete(file_path, ScanCtx.original_table, ScanCtx.new_table);
+    incremental_delete(file_path, ScanCtx.original_table, ScanCtx.copy_table, ScanCtx.new_table);
 
     READ_INDICES(file_path, args->incremental, incremental_copy(source, ScanCtx.index.store, file_path, dst_path, ScanCtx.copy_table), 
                  perror("incremental_copy"), 1);

--- a/src/main.c
+++ b/src/main.c
@@ -489,7 +489,7 @@ void sist2_index(index_args_t *args) {
     snprintf(file_path, PATH_MAX, "%s_index_delete.list.zst", args->index_path);
     if (0 == access(file_path, R_OK)) {
         read_lines(file_path, (line_processor_t) {
-            .data = desc.id,
+            .data = NULL,
             .func = delete_document
         });
         LOG_DEBUGF("main.c", "Read index file %s (%s)", file_path, desc.type)
@@ -698,7 +698,7 @@ int main(int argc, const char *argv[]) {
     exec_args->async_script = common_async_script;
     index_args->async_script = common_async_script;
 
-    scan_args->incremental = common_incremental;
+    scan_args->incremental = (common_incremental == NULL) ? NULL : strdup(common_incremental);
     index_args->incremental = (common_incremental != NULL);
 
     if (argc == 0) {

--- a/src/parsing/parse.c
+++ b/src/parsing/parse.c
@@ -89,9 +89,11 @@ void parse(void *arg) {
 
         return;
     }
-    pthread_mutex_lock(&ScanCtx.copy_table_mu);
-    incremental_mark_file(ScanCtx.new_table, doc->path_md5);
-    pthread_mutex_unlock(&ScanCtx.copy_table_mu);
+    if (ScanCtx.new_table != NULL) {
+        pthread_mutex_lock(&ScanCtx.copy_table_mu);
+        incremental_mark_file(ScanCtx.new_table, doc->path_md5);
+        pthread_mutex_unlock(&ScanCtx.copy_table_mu);
+    }
 
     char *buf[MAGIC_BUF_SIZE];
 

--- a/src/parsing/parse.c
+++ b/src/parsing/parse.c
@@ -81,7 +81,6 @@ void parse(void *arg) {
     if (inc_ts != 0 && inc_ts == job->vfile.info.st_mtim.tv_sec) {
         pthread_mutex_lock(&ScanCtx.copy_table_mu);
         incremental_mark_file(ScanCtx.copy_table, doc->path_md5);
-        incremental_mark_file(ScanCtx.new_table, doc->path_md5);
         pthread_mutex_unlock(&ScanCtx.copy_table_mu);
 
         pthread_mutex_lock(&ScanCtx.dbg_file_counts_mu);

--- a/src/parsing/parse.c
+++ b/src/parsing/parse.c
@@ -80,7 +80,8 @@ void parse(void *arg) {
     int inc_ts = incremental_get(ScanCtx.original_table, doc->path_md5);
     if (inc_ts != 0 && inc_ts == job->vfile.info.st_mtim.tv_sec) {
         pthread_mutex_lock(&ScanCtx.copy_table_mu);
-        incremental_mark_file_for_copy(ScanCtx.copy_table, doc->path_md5);
+        incremental_mark_file(ScanCtx.copy_table, doc->path_md5);
+        incremental_mark_file(ScanCtx.new_table, doc->path_md5);
         pthread_mutex_unlock(&ScanCtx.copy_table_mu);
 
         pthread_mutex_lock(&ScanCtx.dbg_file_counts_mu);
@@ -89,6 +90,9 @@ void parse(void *arg) {
 
         return;
     }
+    pthread_mutex_lock(&ScanCtx.copy_table_mu);
+    incremental_mark_file(ScanCtx.new_table, doc->path_md5);
+    pthread_mutex_unlock(&ScanCtx.copy_table_mu);
 
     char *buf[MAGIC_BUF_SIZE];
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -96,16 +96,8 @@ void fill_tables(cJSON *document, UNUSED(const char index_id[MD5_STR_LENGTH])) {
 }
 
 void read_index_into_tables(index_t *index) {
-    DIR *dir = opendir(index->path);
-    struct dirent *de;
-    while ((de = readdir(dir)) != NULL) {
-        if (strncmp(de->d_name, "_index_", sizeof("_index_") - 1) == 0) {
-            char file_path[PATH_MAX];
-            snprintf(file_path, PATH_MAX, "%s%s", index->path, de->d_name);
-            read_index(file_path, index->desc.id, index->desc.type, fill_tables);
-        }
-    }
-    closedir(dir);
+    char file_path[PATH_MAX];
+    READ_INDICES(file_path, index->path, read_index(file_path, index->desc.id, index->desc.type, fill_tables), {}, 1);
 }
 
 static size_t rfind(const char *str, int c) {

--- a/src/util.h
+++ b/src/util.h
@@ -134,10 +134,11 @@ static int incremental_get_str(GHashTable *table, const char *path_md5) {
 }
 
 /**
- * Not thread safe!
+ * Marks a file by adding it to a table.
+ * !!Not thread safe.
  */
 __always_inline
-static int incremental_mark_file_for_copy(GHashTable *table, const unsigned char path_md5[MD5_DIGEST_LENGTH]) {
+static int incremental_mark_file(GHashTable *table, const unsigned char path_md5[MD5_DIGEST_LENGTH]) {
     char *ptr = malloc(MD5_STR_LENGTH);
     buf2hex(path_md5, MD5_DIGEST_LENGTH, ptr);
     return g_hash_table_insert(table, ptr, GINT_TO_POINTER(1));


### PR DESCRIPTION
~~this is a wip at the moment, as the indexer is not updated.~~

I've also updated the indexer so that it sends {main,original} or {main} to ES, decided by the `--incremental=...` flag.

Implements #225, #226