### PR TITLE
Only remove files with job_name.

### DIFF
--- a/sist2-admin/sist2_admin/state.py
+++ b/sist2-admin/sist2_admin/state.py
@@ -65,8 +65,8 @@ def get_log_files_to_remove(db: PersistentState, job_name: str, n: int):
         if row["name"].endswith(f"[{job_name}]"):
             counter += 1
 
-        if counter > n:
-            to_remove.append(row)
+            if counter > n:
+                to_remove.append(row)
 
     return to_remove
 


### PR DESCRIPTION
As it was - would delete all log files for all jobs once `n` log files for `job_name` were counted. 

Now - only add log files for `job_name` to the delete list once `n` logs counted.