### PR TITLE
fix tail horizontal scrolling

### DIFF
--- a/sist2-admin/frontend/src/views/Tail.vue
+++ b/sist2-admin/frontend/src/views/Tail.vue
@@ -170,6 +170,6 @@ span.ADMIN {
     margin: 3px;
     white-space: pre;
     color: #000;
-    overflow: hidden;
+    overflow-y: hidden;
 }
 </style>


### PR DESCRIPTION
Before this change, debugging via logs was hard due to clipping width of the log box