### PR TITLE
fixed occasional hanging when indexing

### DIFF
--- a/sist2-admin/sist2_admin/jobs.py
+++ b/sist2-admin/sist2_admin/jobs.py
@@ -220,7 +220,7 @@ class Sist2IndexTask(Sist2Task):
             except ProcessLookupError:
                 pass
             try:
-                os.wait()
+                os.waitpid(pid, 0)
             except ChildProcessError:
                 pass
 


### PR DESCRIPTION
os.wait was causing issues occasionally when indexing large datasets #526 